### PR TITLE
feat: :sparkles: Add dotenv configuration and Airtable setup

### DIFF
--- a/FSR-data/main.js
+++ b/FSR-data/main.js
@@ -1,0 +1,11 @@
+require('dotenv').config();
+const monthNames = [
+    '', 'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December'
+];
+
+const Airtable = require('airtable');
+const apiKey = process.env.API_KEY;  // Fetch the API key from environment variables
+const baseId = 'appW8YUaabzGoy0Vq';
+const base = new Airtable({ apiKey }).base(baseId);
+const table = 'Table 1';


### PR DESCRIPTION
Add dotenv configuration to load environment variables and set up Airtable integration in the main.js file.